### PR TITLE
first pass at thread-safe version to use within Glyphs using _Thread_local for global vars

### DIFF
--- a/libpsautohint/include/psautohint.h
+++ b/libpsautohint/include/psautohint.h
@@ -54,6 +54,24 @@ enum
     AC_LogError
 };
 
+#if defined(__has_feature)
+#  if __has_feature(thread_sanitizer)
+/*
+ * Note: ACBuffer internals should be hidden, ACBuffer is only defined
+ *       here when Thread Sanitizer is enabled. Normally in buffer.c.
+ * when hiding struct, Tests.m crashes with Thread Sanitizer (TSan)
+ * in testPerformance...(), but not if Undefined Behavior check enabled.
+ * So, put back in psautohint.h for when using Tsan.
+ */
+#define ACBUFFER_STRUCT_DEFINED
+struct ACBuffer
+{
+    char* data;      /* buffer data, NOT null-terminated */
+    size_t len;      /* actual length of the data */
+    size_t capacity; /* allocated memory size */
+};
+#  endif /* __has_feature(thread_sanitizer) */
+#endif /* __has_feature */
 
 typedef struct ACBuffer ACBuffer;
 

--- a/libpsautohint/src/auto.c
+++ b/libpsautohint/src/auto.c
@@ -9,8 +9,9 @@
 
 #include "ac.h"
 #include "bbox.h"
+#include "logging.h"
 
-static bool mergeMain;
+_Thread_local static bool mergeMain;
 
 static PathElt*
 GetSubPathNxt(PathElt* e)

--- a/libpsautohint/src/bbox.c
+++ b/libpsautohint/src/bbox.c
@@ -9,12 +9,13 @@
 
 #include "bbox.h"
 #include "ac.h"
+#include "logging.h"
 
-static Fixed xmin, ymin, xmax, ymax, vMn, vMx, hMn, hMx;
-static PathElt *pxmn, *pxmx, *pymn, *pymx, *pe, *pvMn, *pvMx, *phMn, *phMx;
+_Thread_local static Fixed xmin, ymin, xmax, ymax, vMn, vMx, hMn, hMx;
+_Thread_local static PathElt *pxmn, *pxmx, *pymn, *pymx, *pe, *pvMn, *pvMx, *phMn, *phMx;
 
 static void
-FPBBoxPt(Cd c, PathElt* eM)
+FPBBoxPt(Cd c)
 {
     if (c.x < xmin) {
         xmin = c.x;
@@ -57,7 +58,7 @@ FindPathBBox(void)
                 c0.x = e->x;
                 c0.y = e->y;
                 pe = e;
-                FPBBoxPt(c0, eM);
+                FPBBoxPt(c0);
                 break;
             case CURVETO:
                 c1.x = e->x1;
@@ -67,7 +68,7 @@ FindPathBBox(void)
                 c3.x = e->x3;
                 c3.y = e->y3;
                 pe = e;
-                FltnCurve(c0, c1, c2, c3, &fr, eM);
+                FltnCurve(c0, c1, c2, c3, &fr);
                 c0 = c3;
                 break;
             case CLOSEPATH:
@@ -115,7 +116,7 @@ FindSubpathBBox(PathElt* e)
                 c0.x = e->x;
                 c0.y = e->y;
                 pe = e;
-                FPBBoxPt(c0, e);
+                FPBBoxPt(c0);
                 break;
             case CURVETO:
                 c1.x = e->x1;
@@ -125,7 +126,7 @@ FindSubpathBBox(PathElt* e)
                 c3.x = e->x3;
                 c3.y = e->y3;
                 pe = e;
-                FltnCurve(c0, c1, c2, c3, &fr, e);
+                FltnCurve(c0, c1, c2, c3, &fr);
                 c0 = c3;
                 break;
             case CLOSEPATH:
@@ -169,8 +170,8 @@ FindCurveBBox(Fixed x0, Fixed y0, Fixed px1, Fixed py1, Fixed px2, Fixed py2,
     c2.y = py2;
     c3.x = x1;
     c3.y = y1;
-    FPBBoxPt(c0, eM);
-    FltnCurve(c0, c1, c2, c3, &fr, eM);
+    FPBBoxPt(c0);
+    FltnCurve(c0, c1, c2, c3, &fr);
     *pllx = FHalfRnd(xmin);
     *plly = FHalfRnd(ymin);
     *purx = FHalfRnd(xmax);

--- a/libpsautohint/src/buffer.c
+++ b/libpsautohint/src/buffer.c
@@ -13,12 +13,21 @@
 #include "memory.h"
 #include "psautohint.h"
 
+#ifndef ACBUFFER_STRUCT_DEFINED
+/*
+ * Note: ACBuffer internals should be hidden, ACBuffer is only defined
+ *       in psautohint.h when Thread Sanitizer is enabled.
+ * when hiding struct, Tests.m crashes with Thread Sanitizer (TSan)
+ * in testPerformance...(), but not if Undefined Behavior check enabled.
+ * So, put back in psautohint.h for when using Tsan.
+ */
 struct ACBuffer
 {
     char* data;      /* buffer data, NOT null-terminated */
     size_t len;      /* actual length of the data */
     size_t capacity; /* allocated memory size */
 };
+#endif /* ! ACBUFFER_STRUCT_DEFINED */
 
 ACLIB_API ACBuffer*
 ACBufferNew(size_t size)

--- a/libpsautohint/src/charpath.c
+++ b/libpsautohint/src/charpath.c
@@ -31,14 +31,14 @@
 #define FLATTEN 4
 #define GHOST 5
 
-static bool firstMT;
-static Cd* refPtArray = NULL;
+_Thread_local static bool firstMT;
+_Thread_local static Cd* refPtArray = NULL;
 // Note: thread-safe: Passing outbuff as arg.
 //static ACBuffer* outbuff;
-static int masterCount;
-static const char** masterNames;
-static PathList* pathlist = NULL;
-static indx hintsMasterIx = 0; /* The index of the master we read hints from */
+_Thread_local static int masterCount;
+_Thread_local static const char** masterNames;
+_Thread_local static PathList* pathlist = NULL;
+_Thread_local static indx hintsMasterIx = 0; /* The index of the master we read hints from */
 
 /* Prototypes */
 static void GetRelativePosition(Fixed, Fixed, Fixed, Fixed, Fixed, Fixed*);

--- a/libpsautohint/src/charpath.h
+++ b/libpsautohint/src/charpath.h
@@ -35,8 +35,8 @@ typedef struct {
   int16_t width;
 } PathList;
 
-extern int32_t gPathEntries;  /* number of elements in a glyph path */
-extern bool gAddHints;  /* whether to include hints in the font */
+_Thread_local extern int32_t gPathEntries;  /* number of elements in a glyph path */
+_Thread_local extern bool gAddHints;  /* whether to include hints in the font */
 
 GlyphPathElt* AppendGlyphPathElement(int);
 

--- a/libpsautohint/src/charpathpriv.c
+++ b/libpsautohint/src/charpathpriv.c
@@ -14,13 +14,13 @@
 #include "charpath.h"
 #include "memory.h"
 
-int32_t gPathEntries = 0; /* number of elements in a glyph path */
-bool gAddHints = true;    /* whether to include hints in the font */
+_Thread_local int32_t gPathEntries = 0; /* number of elements in a glyph path */
+_Thread_local bool gAddHints = true;    /* whether to include hints in the font */
 
 #define MAXPATHELT 100 /* initial maximum number of path elements */
 
-static int32_t maxPathEntries = 0;
-static PathList* currPathList = NULL;
+_Thread_local static int32_t maxPathEntries = 0;
+_Thread_local static PathList* currPathList = NULL;
 
 static void CheckPath(void);
 

--- a/libpsautohint/src/charprop.c
+++ b/libpsautohint/src/charprop.c
@@ -8,11 +8,13 @@
  */
 
 #include "ac.h"
+#include "logging.h"
 
 /* number of default entries in counter hint glyph list. */
 #define COUNTERDEFAULTENTRIES 4
 #define COUNTERLISTSIZE 20
 
+/* re: thread-safe: should be okay as only read, not written to. */
 char* gVHintList[] = { "m",  "M",  "T",  "ellipsis", NULL, NULL, NULL,
                        NULL, NULL, NULL, NULL,       NULL, NULL, NULL,
                        NULL, NULL, NULL, NULL,       NULL, NULL };

--- a/libpsautohint/src/control.c
+++ b/libpsautohint/src/control.c
@@ -9,11 +9,12 @@
 
 #include "ac.h"
 #include "bbox.h"
+#include "logging.h"
 
 static void DoHStems(HintVal* sLst1);
 static void DoVStems(HintVal* sLst);
 
-static bool CounterFailed;
+_Thread_local static bool CounterFailed;
 
 void
 InitAll(int32_t reason)

--- a/libpsautohint/src/fix.c
+++ b/libpsautohint/src/fix.c
@@ -8,8 +8,9 @@
  */
 
 #include "ac.h"
+#include "logging.h"
 
-static Fixed bPrev, tPrev;
+_Thread_local static Fixed bPrev, tPrev;
 
 void
 InitFix(int32_t reason)

--- a/libpsautohint/src/flat.c
+++ b/libpsautohint/src/flat.c
@@ -10,7 +10,7 @@
 #include "ac.h"
 
 static void
-FMiniFltn(Cd f0, Cd f1, Cd f2, Cd f3, FltnRec* pfr, PathElt* e)
+FMiniFltn(Cd f0, Cd f1, Cd f2, Cd f3, FltnRec* pfr)
 {
 /* Like FFltnCurve, but assumes abs(deltas) <= 127 pixels */
 /* 8 bits of fraction gives enough precision for splitting curves */
@@ -234,7 +234,7 @@ FMiniFltn(Cd f0, Cd f1, Cd f2, Cd f3, FltnRec* pfr, PathElt* e)
             c.x = c3x + pfr->llx;
             c.y = c3y + pfr->lly;
         }
-        (*pfr->report)(c, e); /* call FPBBoxPt() to reset bbox. */
+        (*pfr->report)(c); /* call FPBBoxPt() to reset bbox. */
         if (dpth == 0)
             return;
         p -= MiniBlkSz;
@@ -284,7 +284,7 @@ FMiniFltn(Cd f0, Cd f1, Cd f2, Cd f3, FltnRec* pfr, PathElt* e)
 /* abs values of coords must be < 2^14 so will not overflow when
    find midpoint by add and shift */
 static void
-FFltnCurve(Cd c0, Cd c1, Cd c2, Cd c3, FltnRec* pfr, PathElt* e)
+FFltnCurve(Cd c0, Cd c1, Cd c2, Cd c3, FltnRec* pfr)
 {
     Cd d0, d1, d2, d3;
     Fixed llx, lly, urx, ury;
@@ -339,27 +339,27 @@ FFltnCurve(Cd c0, Cd c1, Cd c2, Cd c3, FltnRec* pfr, PathElt* e)
     }
     pfr->llx = llx;
     pfr->lly = lly;
-    FMiniFltn(c0, c1, c2, c3, pfr, e);
+    FMiniFltn(c0, c1, c2, c3, pfr);
     return;
 
 Split:
     /* Split the bez curve in half */
     FixedBezDiv(c0, c1, c2, c3, d0, d1, d2, d3);
     pfr->limit--;
-    FFltnCurve(c0, c1, c2, c3, pfr, e);
-    FFltnCurve(d0, d1, d2, d3, pfr, e);
+    FFltnCurve(c0, c1, c2, c3, pfr);
+    FFltnCurve(d0, d1, d2, d3, pfr);
     pfr->limit++;
     return;
 
 ReportC3:
-    (*pfr->report)(c3, e);
+    (*pfr->report)(c3);
 }
 
 void
-FltnCurve(Cd c0, Cd c1, Cd c2, Cd c3, FltnRec* pfr, PathElt* e)
+FltnCurve(Cd c0, Cd c1, Cd c2, Cd c3, FltnRec* pfr)
 {
     pfr->limit = 6; /* limit on how many times a bez curve can be split in half
                        by recursive calls to FFltnCurve() */
     pfr->feps = FixOne; /* DEBUG 8 BIT FIX */
-    FFltnCurve(c0, c1, c2, c3, pfr, e);
+    FFltnCurve(c0, c1, c2, c3, pfr);
 }

--- a/libpsautohint/src/fontinfo.c
+++ b/libpsautohint/src/fontinfo.c
@@ -9,10 +9,11 @@
 
 #include "fontinfo.h"
 #include "ac.h"
+#include "logging.h"
 
 #define UNDEFINED (INT32_MAX)
 
-int32_t gNumHHints, gNumVHints;
+_Thread_local int32_t gNumHHints, gNumVHints;
 
 static void ParseIntStems(const ACFontInfo* fontinfo, char* kw, bool optional,
                           int32_t maxstems, int* stems, int32_t* pnum);
@@ -317,6 +318,7 @@ FreeFontInfo(ACFontInfo* fontinfo)
     UnallocateMem(fontinfo);
 }
 
+/* thread-safe: should be okay to leave since fontinfo_keys[] is only read from not written to. */
 static char* fontinfo_keys[] = {
     "OrigEmSqUnits", "FontName", "FlexOK",
     /* Blue Values */

--- a/libpsautohint/src/gen.c
+++ b/libpsautohint/src/gen.c
@@ -11,9 +11,10 @@
 
 #include "ac.h"
 #include "bbox.h"
+#include "logging.h"
 
-static SegLnkLst *Hlnks, *Vlnks;
-static int32_t cpFrom, cpTo;
+_Thread_local static SegLnkLst *Hlnks, *Vlnks;
+_Thread_local static int32_t cpFrom, cpTo;
 
 void
 InitGen(int32_t reason)

--- a/libpsautohint/src/head.c
+++ b/libpsautohint/src/head.c
@@ -8,6 +8,7 @@
  */
 
 #include "ac.h"
+#include "logging.h"
 
 PathElt*
 GetDest(PathElt* cldest)

--- a/libpsautohint/src/logging.c
+++ b/libpsautohint/src/logging.c
@@ -10,11 +10,12 @@
 #include <stdarg.h>
 
 #include "ac.h"
+#include "logging.h"
 
-AC_REPORTFUNCPTR gLibReportCB = NULL;
+_Thread_local AC_REPORTFUNCPTR gLibReportCB = NULL;
 
 /* proc to be called from LogMsg if error occurs */
-static int (*errorproc)(int16_t);
+_Thread_local static int (*errorproc)(int16_t);
 
 void
 set_errorproc(int (*userproc)(int16_t))

--- a/libpsautohint/src/logging.h
+++ b/libpsautohint/src/logging.h
@@ -9,6 +9,7 @@
 
 #include "psautohint.h"
 
+//#include "ac.h"
 #include "basic.h"
 
 #ifndef BF_LOGGING_H_
@@ -29,8 +30,9 @@
 #define MAXMSGLEN 500
 
 /* global log function which is supplied by the following */
-extern AC_REPORTFUNCPTR gLibReportCB;
+_Thread_local extern AC_REPORTFUNCPTR gLibReportCB;
 
+// HACK: minimize LogMsg changes by making gGlyphName _Thread_local
 void LogMsg(int16_t, int16_t, char *, ...);
 
 void set_errorproc( int (*)(int16_t) );

--- a/libpsautohint/src/memory.c
+++ b/libpsautohint/src/memory.c
@@ -30,8 +30,8 @@ defaultAC_memmanage(void* ctxptr, void* old, size_t size)
     }
 }
 
-static AC_MEMMANAGEFUNCPTR AC_memmanageFuncPtr = defaultAC_memmanage;
-static void* AC_memmanageCtxPtr = NULL;
+_Thread_local static AC_MEMMANAGEFUNCPTR AC_memmanageFuncPtr = defaultAC_memmanage;
+_Thread_local static void* AC_memmanageCtxPtr = NULL;
 
 void
 setAC_memoryManager(void* ctxptr, AC_MEMMANAGEFUNCPTR func)

--- a/libpsautohint/src/merge.c
+++ b/libpsautohint/src/merge.c
@@ -523,6 +523,6 @@ MergeVals(bool vert)
         NxtVL:
             vLst = vLst->vNxt;
         }
-        vL = vL->vNxt;
+        vL = vL->vNxt;  /* FIXME: this seems to not be needed?, vL gets set to NULL at top of loop? */
     }
 }

--- a/libpsautohint/src/misc.c
+++ b/libpsautohint/src/misc.c
@@ -8,6 +8,7 @@
  */
 
 #include "ac.h"
+#include "logging.h"
 
 int32_t
 CountSubPaths(void)
@@ -217,7 +218,7 @@ TryYFlex(PathElt* e, PathElt* n, Fixed x0, Fixed y0, Fixed x1, Fixed y1)
         return;
     }
     if (AddAutoFlexProp(e, true))
-        ReportAddFlex();
+        ReportAddFlex(&gHasFlex);
 }
 
 static void
@@ -276,7 +277,7 @@ TryXFlex(PathElt* e, PathElt* n, Fixed x0, Fixed y0, Fixed x1, Fixed y1)
         return;
     }
     if (AddAutoFlexProp(e, false))
-        ReportAddFlex();
+        ReportAddFlex(&gHasFlex);
 }
 
 void

--- a/libpsautohint/src/optable.c
+++ b/libpsautohint/src/optable.c
@@ -12,6 +12,7 @@
 #include "optable.h"
 #include "ac.h"
 #include "opcodes.h"
+#include "logging.h"
 
 /*
 Not all of the operators from opcodes.h are initialized here; in

--- a/libpsautohint/src/pick.c
+++ b/libpsautohint/src/pick.c
@@ -9,8 +9,9 @@
 
 #include "ac.h"
 #include "bbox.h"
+#include "logging.h"
 
-static HintVal *Vrejects, *Hrejects;
+_Thread_local static HintVal *Vrejects, *Hrejects;
 
 void
 InitPick(int32_t reason)

--- a/libpsautohint/src/psautohint.c
+++ b/libpsautohint/src/psautohint.c
@@ -13,10 +13,11 @@
 #include "fontinfo.h"
 #include "psautohint.h"
 #include "version.h"
+#include "logging.h"
 
-ACBuffer* gBezOutput = NULL;
+_Thread_local ACBuffer* gBezOutput = NULL;
 
-static jmp_buf aclibmark; /* to handle exit() calls in the library version*/
+_Thread_local static jmp_buf aclibmark; /* to handle exit() calls in the library version*/
 
 ACLIB_API void
 AC_SetMemManager(void* ctxptr, AC_MEMMANAGEFUNCPTR func)

--- a/libpsautohint/src/read.c
+++ b/libpsautohint/src/read.c
@@ -12,16 +12,17 @@
 #include "ac.h"
 #include "charpath.h"
 #include "opcodes.h"
+#include "logging.h"
 
-char gGlyphName[MAX_GLYPHNAME_LEN];
+_Thread_local char gGlyphName[MAX_GLYPHNAME_LEN];
 
-static Fixed currentx, currenty; /* used to calculate absolute coordinates */
-static Fixed tempx, tempy;       /* used to calculate relative coordinates */
+_Thread_local static Fixed currentx, currenty; /* used to calculate absolute coordinates */
+_Thread_local static Fixed tempx, tempy;       /* used to calculate relative coordinates */
 #define STKMAX (20)
-static Fixed stk[STKMAX];
-static int32_t stkindex;
-static bool flex, startchar;
-static bool forMultiMaster, includeHints;
+_Thread_local static Fixed stk[STKMAX];
+_Thread_local static int32_t stkindex;
+_Thread_local static bool flex, startchar;
+_Thread_local static bool forMultiMaster, includeHints;
 /* Reading file for comparison of multiple master data and hint information.
    Reads into GlyphPathElt structure instead of PathElt. */
 

--- a/libpsautohint/src/report.c
+++ b/libpsautohint/src/report.c
@@ -10,6 +10,7 @@
 #include <stdarg.h>
 
 #include "ac.h"
+#include "logging.h"
 
 double
 FixToDbl(Fixed f)
@@ -184,13 +185,16 @@ ShwHV(HintVal* val)
 void
 ShowHVal(HintVal* val)
 {
+#if LOGDEBUG
     Fixed l1, l2, r1, r2;
     Fixed bot, top;
+#endif
     HintSeg* seg = val->vSeg1;
     if (seg == NULL) {
         ShwHV(val);
         return;
     }
+#if LOGDEBUG /* FIXME: Georg: this may not be what you intended as LOGDEBUG == -1 */
     bot = -val->vLoc1;
     top = -val->vLoc2;
     l1 = seg->sMin;
@@ -198,7 +202,6 @@ ShowHVal(HintVal* val)
     seg = val->vSeg2;
     l2 = seg->sMin;
     r2 = seg->sMax;
-#if LOGDEBUG
     LogMsg(LOGDEBUG, OK, "b %g t %g v %g s %g%s l1 %g r1 %g  l2 %g r2 %g",
            FixToDbl(bot), FixToDbl(top), VAL(val->vVal), FixToDbl(val->vSpc),
            val->vGhst ? " G" : "", FixToDbl(l1), FixToDbl(r1), FixToDbl(l2),
@@ -234,13 +237,16 @@ ShwVV(HintVal* val)
 void
 ShowVVal(HintVal* val)
 {
+#if LOGDEBUG
     Fixed b1, b2, t1, t2;
     Fixed lft, rht;
+#endif
     HintSeg* seg = val->vSeg1;
     if (seg == NULL) {
         ShwVV(val);
         return;
     }
+#if LOGDEBUG  /* FIXME: Georg: this may not be what you intended as LOGDEBUG == -1 */
     lft = val->vLoc1;
     rht = val->vLoc2;
     b1 = -seg->sMin;
@@ -248,7 +254,6 @@ ShowVVal(HintVal* val)
     seg = val->vSeg2;
     b2 = -seg->sMin;
     t2 = -seg->sMax;
-#if LOGDEBUG
     LogMsg(LOGDEBUG, OK, "l %g r %g v %g s %g b1 %g t1 %g  b2 %g t2 %g",
            FixToDbl(lft), FixToDbl(rht), VAL(val->vVal), FixToDbl(val->vSpc),
            FixToDbl(b1), FixToDbl(t1), FixToDbl(b2), FixToDbl(t2));

--- a/libpsautohint/src/shuffle.c
+++ b/libpsautohint/src/shuffle.c
@@ -8,10 +8,11 @@
  */
 
 #include "ac.h"
+#include "logging.h"
 #define MAXCNT (100)
 
-static unsigned char* links;
-static int32_t rowcnt;
+_Thread_local static unsigned char* links;
+_Thread_local static int32_t rowcnt;
 
 void
 InitShuffleSubpaths(PathElt* eM)

--- a/libpsautohint/src/write.c
+++ b/libpsautohint/src/write.c
@@ -10,19 +10,20 @@
 #include <math.h>
 
 #include "ac.h"
+#include "logging.h"
 
 #define WRTABS_COMMENT (0)
 
-static Fixed currentx, currenty;
-static bool firstFlex, wrtHintInfo;
+_Thread_local static Fixed currentx, currenty;
+_Thread_local static bool firstFlex, wrtHintInfo;
 #define MAXBUFFLEN 127
-static char S0[MAXBUFFLEN + 1];
-static HintPoint* bst;
-static char bch;
-static Fixed bx, by;
-static bool bstB;
+//static char S0[MAXBUFFLEN + 1];
+_Thread_local static HintPoint* bst;
+_Thread_local static char bch;
+_Thread_local static Fixed bx, by;
+_Thread_local static bool bstB;
 
-static int writeAbsolute = 0;
+_Thread_local static int writeAbsolute = 0;
 
 int32_t
 FRnd(int32_t x)
@@ -43,6 +44,8 @@ FRnd(int32_t x)
 /* Note: The 8 bit fixed fraction cannot support more than 2 decimal places. */
 #define WRTNUM(i) WriteString("%d ", (int32_t)(i))
 #define WRTRNUM(i) WriteString("%0.2f ", round((double)(i)*100) / 100)
+
+#define DEFWITHGBEZ(name, singleargdef) name(singleargdef)
 
 static void
 wrtx(Fixed x)
@@ -124,8 +127,8 @@ wrtya(Fixed y)
 
 /*To avoid pointless hint subs*/
 #define HINTMAXSTR 2048
-static char hintmaskstr[HINTMAXSTR];
-static char prevhintmaskstr[HINTMAXSTR];
+_Thread_local static char hintmaskstr[HINTMAXSTR];
+_Thread_local static char prevhintmaskstr[HINTMAXSTR];
 
 static void
 safestrcat(char* s1, char* s2)
@@ -141,12 +144,14 @@ safestrcat(char* s1, char* s2)
 
 #define SWRTNUM(i)                                                             \
     {                                                                          \
+        char S0[MAXBUFFLEN + 1];                                               \
         snprintf(S0, MAXBUFFLEN, "%d ", (int32_t)(i));                         \
         sws(S0);                                                               \
     }
 
 #define SWRTNUMA(i)                                                            \
     {                                                                          \
+        char S0[MAXBUFFLEN + 1];                                               \
         snprintf(S0, MAXBUFFLEN, "%0.2f ", roundf((float)(i)*100) / 100);      \
         sws(S0);                                                               \
     }
@@ -344,8 +349,8 @@ dt(Cd c, PathElt* e)
     }
 }
 
-static Fixed flX, flY;
-static Cd fc1, fc2, fc3;
+_Thread_local static Fixed flX, flY;
+_Thread_local static Cd fc1, fc2, fc3;
 
 #define wrtpreflx2(c)                                                          \
     wrtcd(c);                                                                  \


### PR DESCRIPTION
_[ Partially copied from my email to Georg last night. ]_

I believe the changes committed to the _MakeThreadSave_ branch of psautohint [in this pull request] should allow you to call it from within Glyphs. Short version: ended up backing out mostly of passing along the global state and used C11's `_Thread_local `for all global and file-scoped static variables.

For an interim test, perhaps it would be useful to have an internal option in Glyphs to switch between calling `AutoHintString()` directly or using the compiled binary with the time to hint logged.

Though not included in this commit, I did add some tests for multiple calls and even calling the external binary (hardcoded on my installed path) for some rough tests, along with adding `testPerformance...()` that simply called those routines in a `measureBlock`. The multiple internal routine calls test needs to be cleaned up and refactored to make it simpler to add more test data before committing.

**Couple quick questions:** In the WIP very early commit, you commented out a couple routines:
	- `chkBad()`
	- `ReportLinearCurve()`
**Was that for some reason other than the thread-safe work?** I uncommented `chkBad()` in this commit, but left `ReportLinearCurve()` commented out. Mentioning in case commenting out `chkBad()` was intentional and should be commented out, again.

Also, I saw reference to` #if LOGDEBUG` in report.c mentioned in commit 5cf7d0e as performance. I don't think that did what you want. `LOGDEBUG` is really `AC_LogDebug` which is equal to `-1`. So, the `#if LOGDEBUG` is `#if -1` and would always be included.